### PR TITLE
Initialize uninitialized double values during gain calculation

### DIFF
--- a/source/PointSourcePannerGainCalc.cpp
+++ b/source/PointSourcePannerGainCalc.cpp
@@ -219,11 +219,11 @@ void CPointSourcePannerGainCalc::CalculateGains(CartesianPosition position, std:
 		for (int i = 0; i < 2; ++i)
 			for (int j = 0; j < 5; ++j)
 				gains[i] += stereoDownmix[i][j] * m_gainsTmp[j];
-		double a_front;
+		double a_front = 0;
 		int i = 0;
 		for (i = 0; i < 3; ++i)
 			a_front = std::max(a_front, m_gainsTmp[i]);
-		double a_rear;
+		double a_rear = 0;
 		for (i = 3; i < 5; ++i)
 			a_rear = std::max(a_rear, m_gainsTmp[i]);
 		double r = a_rear / (a_front + a_rear);


### PR DESCRIPTION
When compiling for release using Clang 14.0.3, these 2 doubles are uninitialized, causing them to be arbitrary values, which leads to errors in the gain calculations. Note that I only encountered the problem on non-debug builds and only when panning to the stereo layout, debug builds and non-stereo layouts seem to work fine.

To reproduce the issue:
- Configure an ADM renderer rendering to ITU_0_2_0
- Create a single object taking a mono channel buffer
- Create a mono channel buffer containing a sin wave with 1024 samples
- Place the object at 0,0,0
- Add the object + mono buffer to the renderer
- Perform a render using GetRendererAudio
- All values in the returned stereo channel buffer will be NaN

Initializing these uninitialized variables resolves the issue.

Working with libspatialaudio on Mac Sonoma 14.7.1, compiling with Clang 14.0.3.

Please let me know if I can provide any additional information, formatting, etc.